### PR TITLE
Isolate RFC6979 for unit testing

### DIFF
--- a/ecurve.js
+++ b/ecurve.js
@@ -1,7 +1,7 @@
-let BN = require('bn.js')
-let createHmac = require('create-hmac')
-let EC = require('elliptic').ec
-let secp256k1 = new EC('secp256k1')
+const BN = require('bn.js')
+const EC = require('elliptic').ec
+const secp256k1 = new EC('secp256k1')
+const createHmac = require('create-hmac')
 
 const ONE1 = Buffer.alloc(1, 1)
 const ZERO1 = Buffer.alloc(1, 0)
@@ -13,11 +13,11 @@ const n = secp256k1.curve.n
 const nDiv2 = n.shrn(1)
 const G = secp256k1.curve.g
 
-let THROW_BAD_PRIVATE = 'Expected Private'
-let THROW_BAD_POINT = 'Expected Point'
-let THROW_BAD_TWEAK = 'Expected Tweak'
-let THROW_BAD_HASH = 'Expected Hash'
-let THROW_BAD_SIGNATURE = 'Expected Signature'
+const THROW_BAD_PRIVATE = 'Expected Private'
+const THROW_BAD_POINT = 'Expected Point'
+const THROW_BAD_TWEAK = 'Expected Tweak'
+const THROW_BAD_HASH = 'Expected Hash'
+const THROW_BAD_SIGNATURE = 'Expected Signature'
 
 function isScalar (x) {
   return Buffer.isBuffer(x) && x.length === 32
@@ -32,13 +32,13 @@ function isPoint (p) {
   if (!Buffer.isBuffer(p)) return false
   if (p.length < 33) return false
 
-  let t = p[0]
-  let x = p.slice(1, 33)
+  const t = p[0]
+  const x = p.slice(1, 33)
   if (x.compare(ZERO32) === 0) return false
   if (x.compare(EC_P) >= 0) return false
   if ((t === 0x02 || t === 0x03) && p.length === 33) return true
 
-  let y = p.slice(33)
+  const y = p.slice(33)
   if (y.compare(ZERO32) === 0) return false
   if (y.compare(EC_P) >= 0) return false
   if (t === 0x04 && p.length === 65) return true
@@ -61,8 +61,8 @@ function isPrivate (x) {
 }
 
 function isSignature (value) {
-  let r = value.slice(0, 32)
-  let s = value.slice(32, 64)
+  const r = value.slice(0, 32)
+  const s = value.slice(32, 64)
   return Buffer.isBuffer(value) && value.length === 64 &&
     r.compare(EC_GROUP_ORDER) < 0 &&
     s.compare(EC_GROUP_ORDER) < 0
@@ -83,12 +83,12 @@ function pointAdd (pA, pB, __compressed) {
   if (!isPoint(pA)) throw new TypeError(THROW_BAD_POINT)
   if (!isPoint(pB)) throw new TypeError(THROW_BAD_POINT)
 
-  let a = decodeFrom(pA)
-  let b = decodeFrom(pB)
-  let pp = a.add(b)
+  const a = decodeFrom(pA)
+  const b = decodeFrom(pB)
+  const pp = a.add(b)
   if (pp.isInfinity()) return null
 
-  let compressed = assumeCompression(__compressed, pA)
+  const compressed = assumeCompression(__compressed, pA)
   return getEncoded(pp, compressed)
 }
 
@@ -96,13 +96,13 @@ function pointAddScalar (p, tweak, __compressed) {
   if (!isPoint(p)) throw new TypeError(THROW_BAD_POINT)
   if (!isOrderScalar(tweak)) throw new TypeError(THROW_BAD_TWEAK)
 
-  let compressed = assumeCompression(__compressed, p)
-  let pp = decodeFrom(p)
+  const compressed = assumeCompression(__compressed, p)
+  const pp = decodeFrom(p)
   if (tweak.compare(ZERO32) === 0) return getEncoded(pp, compressed)
 
-  let tt = fromBuffer(tweak)
-  let qq = G.mul(tt)
-  let uu = pp.add(qq)
+  const tt = fromBuffer(tweak)
+  const qq = G.mul(tt)
+  const uu = pp.add(qq)
   if (uu.isInfinity()) return null
 
   return getEncoded(uu, compressed)
@@ -111,7 +111,7 @@ function pointAddScalar (p, tweak, __compressed) {
 function pointCompress (p, compressed) {
   if (!isPoint(p)) throw new TypeError(THROW_BAD_POINT)
 
-  let pp = decodeFrom(p)
+  const pp = decodeFrom(p)
   if (pp.isInfinity()) throw new TypeError(THROW_BAD_POINT)
 
   return getEncoded(pp, compressed)
@@ -120,11 +120,11 @@ function pointCompress (p, compressed) {
 function pointFromScalar (d, __compressed) {
   if (!isPrivate(d)) throw new TypeError(THROW_BAD_PRIVATE)
 
-  let dd = fromBuffer(d)
-  let pp = G.mul(dd)
+  const dd = fromBuffer(d)
+  const pp = G.mul(dd)
   if (pp.isInfinity()) return null
 
-  let compressed = assumeCompression(__compressed)
+  const compressed = assumeCompression(__compressed)
   return getEncoded(pp, compressed)
 }
 
@@ -132,10 +132,10 @@ function pointMultiply (p, tweak, __compressed) {
   if (!isPoint(p)) throw new TypeError(THROW_BAD_POINT)
   if (!isOrderScalar(tweak)) throw new TypeError(THROW_BAD_TWEAK)
 
-  let compressed = assumeCompression(__compressed, p)
-  let pp = decodeFrom(p)
-  let tt = fromBuffer(tweak)
-  let qq = pp.mul(tt)
+  const compressed = assumeCompression(__compressed, p)
+  const pp = decodeFrom(p)
+  const tt = fromBuffer(tweak)
+  const qq = pp.mul(tt)
   if (qq.isInfinity()) return null
 
   return getEncoded(qq, compressed)
@@ -145,9 +145,9 @@ function privateAdd (d, tweak) {
   if (!isPrivate(d)) throw new TypeError(THROW_BAD_PRIVATE)
   if (!isOrderScalar(tweak)) throw new TypeError(THROW_BAD_TWEAK)
 
-  let dd = fromBuffer(d)
-  let tt = fromBuffer(tweak)
-  let dt = toBuffer(dd.add(tt).umod(n))
+  const dd = fromBuffer(d)
+  const tt = fromBuffer(tweak)
+  const dt = toBuffer(dd.add(tt).umod(n))
   if (!isPrivate(dt)) return null
 
   return dt
@@ -157,9 +157,9 @@ function privateSub (d, tweak) {
   if (!isPrivate(d)) throw new TypeError(THROW_BAD_PRIVATE)
   if (!isOrderScalar(tweak)) throw new TypeError(THROW_BAD_TWEAK)
 
-  let dd = fromBuffer(d)
-  let tt = fromBuffer(tweak)
-  let dt = toBuffer(dd.sub(tt).umod(n))
+  const dd = fromBuffer(d)
+  const tt = fromBuffer(tweak)
+  const dt = toBuffer(dd.sub(tt).umod(n))
   if (!isPrivate(dt)) return null
 
   return dt
@@ -223,13 +223,13 @@ function sign (hash, x) {
   if (!isScalar(hash)) throw new TypeError(THROW_BAD_HASH)
   if (!isPrivate(x)) throw new TypeError(THROW_BAD_PRIVATE)
 
-  let d = fromBuffer(x)
-  let e = fromBuffer(hash)
+  const d = fromBuffer(x)
+  const e = fromBuffer(hash)
 
   let r, s
   deterministicGenerateK(hash, x, function (k) {
-    let kI = fromBuffer(k)
-    let Q = G.mul(kI)
+    const kI = fromBuffer(k)
+    const Q = G.mul(kI)
 
     if (Q.isInfinity()) return false
 
@@ -250,7 +250,7 @@ function sign (hash, x) {
     s = n.sub(s)
   }
 
-  let buffer = Buffer.allocUnsafe(64)
+  const buffer = Buffer.allocUnsafe(64)
   toBuffer(r).copy(buffer, 0)
   toBuffer(s).copy(buffer, 32)
   return buffer
@@ -263,9 +263,9 @@ function verify (hash, q, signature) {
   // 1.4.1 Enforce r and s are both integers in the interval [1, n − 1] (1, isSignature enforces '< n - 1')
   if (!isSignature(signature)) throw new TypeError(THROW_BAD_SIGNATURE)
 
-  let Q = decodeFrom(q)
-  let r = fromBuffer(signature.slice(0, 32))
-  let s = fromBuffer(signature.slice(32, 64))
+  const Q = decodeFrom(q)
+  const r = fromBuffer(signature.slice(0, 32))
+  const s = fromBuffer(signature.slice(32, 64))
 
   // 1.4.1 Enforce r and s are both integers in the interval [1, n − 1] (2, enforces '> 0')
   if (r.gtn(0) <= 0 /* || r.compareTo(n) >= 0 */) return false
@@ -273,28 +273,28 @@ function verify (hash, q, signature) {
 
   // 1.4.2 H = Hash(M), already done by the user
   // 1.4.3 e = H
-  let e = fromBuffer(hash)
+  const e = fromBuffer(hash)
 
   // Compute s^-1
-  let sInv = s.invm(n)
+  const sInv = s.invm(n)
 
   // 1.4.4 Compute u1 = es^−1 mod n
   //               u2 = rs^−1 mod n
-  let u1 = e.mul(sInv).umod(n)
-  let u2 = r.mul(sInv).umod(n)
+  const u1 = e.mul(sInv).umod(n)
+  const u2 = r.mul(sInv).umod(n)
 
   // 1.4.5 Compute R = (xR, yR)
   //               R = u1G + u2Q
-  let R = G.mulAdd(u1, Q, u2)
+  const R = G.mulAdd(u1, Q, u2)
 
   // 1.4.5 (cont.) Enforce R is not at infinity
   if (R.isInfinity()) return false
 
   // 1.4.6 Convert the field element R.x to an integer
-  let xR = R.x
+  const xR = R.x
 
   // 1.4.7 Set v = xR mod n
-  let v = xR.umod(n)
+  const v = xR.umod(n)
 
   // 1.4.8 If v = r, output "valid", and if v != r, output "invalid"
   return v.eq(r)

--- a/rfc6979.js
+++ b/rfc6979.js
@@ -1,0 +1,60 @@
+const createHmac = require('create-hmac')
+
+const ONE1 = Buffer.alloc(1, 1)
+const ZERO1 = Buffer.alloc(1, 0)
+
+// https://tools.ietf.org/html/rfc6979#section-3.2
+function deterministicGenerateK (hash, x, checkSig, isPrivate) {
+  // Step A, ignored as hash already provided
+  // Step B
+  // Step C
+  let k = Buffer.alloc(32, 0)
+  let v = Buffer.alloc(32, 1)
+
+  // Step D
+  k = createHmac('sha256', k)
+    .update(v)
+    .update(ZERO1)
+    .update(x)
+    .update(hash)
+    .digest()
+
+  // Step E
+  v = createHmac('sha256', k).update(v).digest()
+
+  // Step F
+  k = createHmac('sha256', k)
+    .update(v)
+    .update(ONE1)
+    .update(x)
+    .update(hash)
+    .digest()
+
+  // Step G
+  v = createHmac('sha256', k).update(v).digest()
+
+  // Step H1/H2a, ignored as tlen === qlen (256 bit)
+  // Step H2b
+  v = createHmac('sha256', k).update(v).digest()
+
+  let T = v
+
+  // Step H3, repeat until T is within the interval [1, n - 1] and is suitable for ECDSA
+  while (!isPrivate(T) || !checkSig(T)) {
+    k = createHmac('sha256', k)
+      .update(v)
+      .update(ZERO1)
+      .digest()
+
+    v = createHmac('sha256', k).update(v).digest()
+
+    // Step H1/H2a, again, ignored as tlen === qlen (256 bit)
+    // Step H2b again
+    v = createHmac('sha256', k).update(v).digest()
+    T = v
+  }
+
+  return T
+}
+
+module.exports = deterministicGenerateK

--- a/tests/ecdsa.js
+++ b/tests/ecdsa.js
@@ -1,5 +1,5 @@
-let tape = require('tape')
-let fecdsa = require('./fixtures/ecdsa.json')
+const tape = require('tape')
+const fecdsa = require('./fixtures/ecdsa.json')
 
 function corrupt (x) {
   function randomUInt8 () {
@@ -7,7 +7,7 @@ function corrupt (x) {
   }
 
   x = Buffer.from(x)
-  let mask = 1 << (randomUInt8() % 8)
+  const mask = 1 << (randomUInt8() % 8)
   x[randomUInt8() % 32] ^= mask
   return x
 }
@@ -15,16 +15,16 @@ function corrupt (x) {
 function test (binding) {
   tape('sign', (t) => {
     fecdsa.valid.forEach((f) => {
-      let d = Buffer.from(f.d, 'hex')
-      let m = Buffer.from(f.m, 'hex')
-      let expected = Buffer.from(f.signature, 'hex')
+      const d = Buffer.from(f.d, 'hex')
+      const m = Buffer.from(f.m, 'hex')
+      const expected = Buffer.from(f.signature, 'hex')
 
       t.same(binding.sign(m, d), expected, `sign(${f.m}, ...) == ${f.signature}`)
     })
 
     fecdsa.invalid.sign.forEach((f) => {
-      let d = Buffer.from(f.d, 'hex')
-      let m = Buffer.from(f.m, 'hex')
+      const d = Buffer.from(f.d, 'hex')
+      const m = Buffer.from(f.m, 'hex')
 
       t.throws(() => {
         binding.sign(m, d)
@@ -36,12 +36,12 @@ function test (binding) {
 
   tape('verify', (t) => {
     fecdsa.valid.forEach((f) => {
-      let d = Buffer.from(f.d, 'hex')
-      let Q = binding.pointFromScalar(d, true)
-      let Qu = binding.pointFromScalar(d, false)
-      let m = Buffer.from(f.m, 'hex')
-      let signature = Buffer.from(f.signature, 'hex')
-      let bad = corrupt(signature)
+      const d = Buffer.from(f.d, 'hex')
+      const Q = binding.pointFromScalar(d, true)
+      const Qu = binding.pointFromScalar(d, false)
+      const m = Buffer.from(f.m, 'hex')
+      const signature = Buffer.from(f.signature, 'hex')
+      const bad = corrupt(signature)
 
       t.equal(binding.verify(m, Q, signature), true, `verify(${f.signature}) is OK`)
       t.equal(binding.verify(m, Q, bad), false, `verify(${bad.toString('hex')}) is rejected`)
@@ -50,9 +50,9 @@ function test (binding) {
     })
 
     fecdsa.invalid.verify.forEach((f) => {
-      let Q = Buffer.from(f.Q, 'hex')
-      let m = Buffer.from(f.m, 'hex')
-      let signature = Buffer.from(f.signature, 'hex')
+      const Q = Buffer.from(f.Q, 'hex')
+      const m = Buffer.from(f.m, 'hex')
+      const signature = Buffer.from(f.signature, 'hex')
 
       if (f.exception) {
         t.throws(() => {

--- a/tests/fixtures/rfc6979.json
+++ b/tests/fixtures/rfc6979.json
@@ -1,0 +1,72 @@
+[
+  {
+    "message": "test data",
+    "d": "fee0a1f7afebf9d2a5a80c0c98a31c709681cce195cbcd06342b517970c0be1e",
+    "k0": "fcce1de7a9bcd6b2d3defade6afa1913fb9229e3b7ddf4749b55c4848b2a196e",
+    "k1": "727fbcb59eb48b1d7d46f95a04991fc512eb9dbf9105628e3aec87428df28fd8",
+    "k15": "398f0e2c9f79728f7b3d84d447ac3a86d8b2083c8f234a0ffa9c4043d68bd258"
+  },
+  {
+    "message": "Everything should be made as simple as possible, but not simpler.",
+    "d": "0000000000000000000000000000000000000000000000000000000000000001",
+    "k0": "ec633bd56a5774a0940cb97e27a9e4e51dc94af737596a0c5cbb3d30332d92a5",
+    "k1": "df55b6d1b5c48184622b0ead41a0e02bfa5ac3ebdb4c34701454e80aabf36f56",
+    "k15": "def007a9a3c2f7c769c75da9d47f2af84075af95cadd1407393dc1e26086ef87"
+  },
+  {
+    "message": "Satoshi Nakamoto",
+    "d": "0000000000000000000000000000000000000000000000000000000000000002",
+    "k0": "d3edc1b8224e953f6ee05c8bbf7ae228f461030e47caf97cde91430b4607405e",
+    "k1": "f86d8e43c09a6a83953f0ab6d0af59fb7446b4660119902e9967067596b58374",
+    "k15": "241d1f57d6cfd2f73b1ada7907b199951f95ef5ad362b13aed84009656e0254a"
+  },
+  {
+    "message": "Diffie Hellman",
+    "d": "7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f",
+    "k0": "c378a41cb17dce12340788dd3503635f54f894c306d52f6e9bc4b8f18d27afcc",
+    "k1": "90756c96fef41152ac9abe08819c4e95f16da2af472880192c69a2b7bac29114",
+    "k15": "7b3f53300ab0ccd0f698f4d67db87c44cf3e9e513d9df61137256652b2e94e7c"
+  },
+  {
+    "message": "Japan",
+    "d": "8080808080808080808080808080808080808080808080808080808080808080",
+    "k0": "f471e61b51d2d8db78f3dae19d973616f57cdc54caaa81c269394b8c34edcf59",
+    "k1": "6819d85b9730acc876fdf59e162bf309e9f63dd35550edf20869d23c2f3e6d17",
+    "k15": "d8e8bae3ee330a198d1f5e00ad7c5f9ed7c24c357c0a004322abca5d9cd17847"
+  },
+  {
+    "message": "Bitcoin",
+    "d": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+    "k0": "36c848ffb2cbecc5422c33a994955b807665317c1ce2a0f59c689321aaa631cc",
+    "k1": "4ed8de1ec952a4f5b3bd79d1ff96446bcd45cabb00fc6ca127183e14671bcb85",
+    "k15": "56b6f47babc1662c011d3b1f93aa51a6e9b5f6512e9f2e16821a238d450a31f8"
+  },
+  {
+    "message": "i2FLPP8WEus5WPjpoHwheXOMSobUJVaZM1JPMQZq",
+    "d": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+    "k0": "6e9b434fcc6bbb081a0463c094356b47d62d7efae7da9c518ed7bac23f4e2ed6",
+    "k1": "ae5323ae338d6117ce8520a43b92eacd2ea1312ae514d53d8e34010154c593bb",
+    "k15": "3eaa1b61d1b8ab2f1ca71219c399f2b8b3defa624719f1e96fe3957628c2c4ea"
+  },
+  {
+    "message": "lEE55EJNP7aLrMtjkeJKKux4Yg0E8E1SAJnWTCEh",
+    "d": "3881e5286abc580bb6139fe8e83d7c8271c6fe5e5c2d640c1f0ed0e1ee37edc9",
+    "k0": "5b606665a16da29cc1c5411d744ab554640479dd8abd3c04ff23bd6b302e7034",
+    "k1": "f8b25263152c042807c992eacd2ac2cc5790d1e9957c394f77ea368e3d9923bd",
+    "k15": "ea624578f7e7964ac1d84adb5b5087dd14f0ee78b49072aa19051cc15dab6f33"
+  },
+  {
+    "message": "2SaVPvhxkAPrayIVKcsoQO5DKA8Uv5X/esZFlf+y",
+    "d": "7259dff07922de7f9c4c5720d68c9745e230b32508c497dd24cb95ef18856631",
+    "k0": "3ab6c19ab5d3aea6aa0c6da37516b1d6e28e3985019b3adb388714e8f536686b",
+    "k1": "19af21b05004b0ce9cdca82458a371a9d2cf0dc35a813108c557b551c08eb52e",
+    "k15": "117a32665fca1b7137a91c4739ac5719fec0cf2e146f40f8e7c21b45a07ebc6a"
+  },
+  {
+    "message": "00A0OwO2THi7j5Z/jp0FmN6nn7N/DQd6eBnCS+/b",
+    "d": "0d6ea45d62b334777d6995052965c795a4f8506044b4fd7dc59c15656a28f7aa",
+    "k0": "79487de0c8799158294d94c0eb92ee4b567e4dc7ca18addc86e49d31ce1d2db6",
+    "k1": "9561d2401164a48a8f600882753b3105ebdd35e2358f4f808c4f549c91490009",
+    "k15": "b0d273634129ff4dbdf0df317d4062a1dbc58818f88878ffdb4ec511c77976c0"
+  }
+]

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,11 +1,11 @@
-let ecurve = require('../ecurve')
+const ecurve = require('../ecurve')
 
 require('./ecdsa')(ecurve)
 require('./privates')(ecurve)
 require('./points')(ecurve)
 
 try {
-  let native = require('bindings')('secp256k1')
+  const native = require('bindings')('secp256k1')
   require('./ecdsa')(native)
   require('./privates')(native)
   require('./points')(native)

--- a/tests/points.js
+++ b/tests/points.js
@@ -1,10 +1,10 @@
-let tape = require('tape')
-let fpoints = require('./fixtures/points.json')
+const tape = require('tape')
+const fpoints = require('./fixtures/points.json')
 
 function test (binding) {
   tape('isPoint', (t) => {
     fpoints.valid.isPoint.forEach((f) => {
-      let p = Buffer.from(f.P, 'hex')
+      const p = Buffer.from(f.P, 'hex')
 
       t.equal(binding.isPoint(p), f.expected, `${f.P} is ${f.expected ? 'OK' : 'rejected'}`)
     })
@@ -15,8 +15,8 @@ function test (binding) {
   tape('isPointCompressed', (t) => {
     fpoints.valid.isPoint.forEach((f) => {
       if (!f.expected) return
-      let p = Buffer.from(f.P, 'hex')
-      let e = p.length === 33
+      const p = Buffer.from(f.P, 'hex')
+      const e = p.length === 33
 
       t.equal(binding.isPointCompressed(p), e, `${f.P} is ${e ? 'compressed' : 'uncompressed'}`)
     })
@@ -26,10 +26,10 @@ function test (binding) {
 
   tape('pointAdd', (t) => {
     fpoints.valid.pointAdd.forEach((f) => {
-      let p = Buffer.from(f.P, 'hex')
-      let q = Buffer.from(f.Q, 'hex')
+      const p = Buffer.from(f.P, 'hex')
+      const q = Buffer.from(f.Q, 'hex')
 
-      let expected = f.expected ? Buffer.from(f.expected, 'hex') : null
+      const expected = f.expected ? Buffer.from(f.expected, 'hex') : null
       let description = `${f.P} + ${f.Q} = ${f.expected ? f.expected : null}`
       if (f.description) description += ` (${f.description})`
 
@@ -41,8 +41,8 @@ function test (binding) {
     })
 
     fpoints.invalid.pointAdd.forEach((f) => {
-      let p = Buffer.from(f.P, 'hex')
-      let q = Buffer.from(f.Q, 'hex')
+      const p = Buffer.from(f.P, 'hex')
+      const q = Buffer.from(f.Q, 'hex')
 
       t.throws(() => {
         binding.pointAdd(p, q)
@@ -54,10 +54,10 @@ function test (binding) {
 
   tape('pointAddScalar', (t) => {
     fpoints.valid.pointAddScalar.forEach((f) => {
-      let p = Buffer.from(f.P, 'hex')
-      let d = Buffer.from(f.d, 'hex')
+      const p = Buffer.from(f.P, 'hex')
+      const d = Buffer.from(f.d, 'hex')
 
-      let expected = f.expected ? Buffer.from(f.expected, 'hex') : null
+      const expected = f.expected ? Buffer.from(f.expected, 'hex') : null
       let description = `${f.P} + ${f.d} = ${f.expected ? f.expected : null}`
       if (f.description) description += ` (${f.description})`
 
@@ -69,8 +69,8 @@ function test (binding) {
     })
 
     fpoints.invalid.pointAddScalar.forEach((f) => {
-      let p = Buffer.from(f.P, 'hex')
-      let d = Buffer.from(f.d, 'hex')
+      const p = Buffer.from(f.P, 'hex')
+      const d = Buffer.from(f.d, 'hex')
 
       t.throws(() => {
         binding.pointAddScalar(p, d)
@@ -82,14 +82,14 @@ function test (binding) {
 
   tape('pointCompress', (t) => {
     fpoints.valid.pointCompress.forEach((f) => {
-      let p = Buffer.from(f.P, 'hex')
-      let expected = f.expected ? Buffer.from(f.expected, 'hex') : null
+      const p = Buffer.from(f.P, 'hex')
+      const expected = f.expected ? Buffer.from(f.expected, 'hex') : null
 
       t.same(binding.pointCompress(p, f.compress), expected)
     })
 
     fpoints.invalid.pointCompress.forEach((f) => {
-      let p = Buffer.from(f.P, 'hex')
+      const p = Buffer.from(f.P, 'hex')
 
       t.throws(() => {
         binding.pointCompress(p)
@@ -101,9 +101,9 @@ function test (binding) {
 
   tape('pointFromScalar', (t) => {
     fpoints.valid.pointFromScalar.forEach((f) => {
-      let d = Buffer.from(f.d, 'hex')
+      const d = Buffer.from(f.d, 'hex')
 
-      let expected = f.expected ? Buffer.from(f.expected, 'hex') : null
+      const expected = f.expected ? Buffer.from(f.expected, 'hex') : null
       let description = `${f.d} * G = ${f.expected ? f.expected : null}`
       if (f.description) description += ` (${f.description})`
 
@@ -115,7 +115,7 @@ function test (binding) {
     })
 
     fpoints.invalid.pointFromScalar.forEach((f) => {
-      let d = Buffer.from(f.d, 'hex')
+      const d = Buffer.from(f.d, 'hex')
 
       t.throws(() => {
         binding.pointFromScalar(d)
@@ -127,10 +127,10 @@ function test (binding) {
 
   tape('pointMultiply', (t) => {
     fpoints.valid.pointMultiply.forEach((f) => {
-      let p = Buffer.from(f.P, 'hex')
-      let d = Buffer.from(f.d, 'hex')
+      const p = Buffer.from(f.P, 'hex')
+      const d = Buffer.from(f.d, 'hex')
 
-      let expected = f.expected ? Buffer.from(f.expected, 'hex') : null
+      const expected = f.expected ? Buffer.from(f.expected, 'hex') : null
       let description = `${f.P} * ${f.d} = ${f.expected ? f.expected : null}`
       if (f.description) description += ` (${f.description})`
 
@@ -142,8 +142,8 @@ function test (binding) {
     })
 
     fpoints.invalid.pointMultiply.forEach((f) => {
-      let p = Buffer.from(f.P, 'hex')
-      let d = Buffer.from(f.d, 'hex')
+      const p = Buffer.from(f.P, 'hex')
+      const d = Buffer.from(f.d, 'hex')
 
       t.throws(() => {
         binding.pointMultiply(p, d)

--- a/tests/privates.js
+++ b/tests/privates.js
@@ -1,10 +1,10 @@
-let tape = require('tape')
-let fprivates = require('./fixtures/privates.json')
+const tape = require('tape')
+const fprivates = require('./fixtures/privates.json')
 
 function test (binding) {
   tape('isPrivate', (t) => {
     fprivates.valid.isPrivate.forEach((f) => {
-      let d = Buffer.from(f.d, 'hex')
+      const d = Buffer.from(f.d, 'hex')
 
       t.equal(binding.isPrivate(d), f.expected, `${f.d} is ${f.expected ? 'OK' : 'rejected'}`)
     })
@@ -14,9 +14,9 @@ function test (binding) {
 
   tape('privateAdd', (t) => {
     fprivates.valid.privateAdd.forEach((f) => {
-      let d = Buffer.from(f.d, 'hex')
-      let tweak = Buffer.from(f.tweak, 'hex')
-      let expected = f.expected ? Buffer.from(f.expected, 'hex') : null
+      const d = Buffer.from(f.d, 'hex')
+      const tweak = Buffer.from(f.tweak, 'hex')
+      const expected = f.expected ? Buffer.from(f.expected, 'hex') : null
       let description = `${f.d} + ${f.tweak} = ${f.expected ? f.expected : null}`
       if (f.description) description += ` (${f.description})`
 
@@ -24,8 +24,8 @@ function test (binding) {
     })
 
     fprivates.invalid.privateAdd.forEach((f) => {
-      let d = Buffer.from(f.d, 'hex')
-      let tweak = Buffer.from(f.tweak, 'hex')
+      const d = Buffer.from(f.d, 'hex')
+      const tweak = Buffer.from(f.tweak, 'hex')
 
       t.throws(() => {
         binding.privateAdd(d, tweak)
@@ -37,9 +37,9 @@ function test (binding) {
 
   tape('privateSub', (t) => {
     fprivates.valid.privateSub.forEach((f) => {
-      let d = Buffer.from(f.d, 'hex')
-      let tweak = Buffer.from(f.tweak, 'hex')
-      let expected = f.expected ? Buffer.from(f.expected, 'hex') : null
+      const d = Buffer.from(f.d, 'hex')
+      const tweak = Buffer.from(f.tweak, 'hex')
+      const expected = f.expected ? Buffer.from(f.expected, 'hex') : null
       let description = `${f.d} - ${f.tweak} = ${f.expected ? f.expected : null}`
       if (f.description) description += ` (${f.description})`
 
@@ -47,8 +47,8 @@ function test (binding) {
     })
 
     fprivates.invalid.privateSub.forEach((f) => {
-      let d = Buffer.from(f.d, 'hex')
-      let tweak = Buffer.from(f.tweak, 'hex')
+      const d = Buffer.from(f.d, 'hex')
+      const tweak = Buffer.from(f.tweak, 'hex')
 
       t.throws(() => {
         binding.privateSub(d, tweak)

--- a/tests/rfc6979.js
+++ b/tests/rfc6979.js
@@ -1,0 +1,25 @@
+const tape = require('tape')
+const createHash = require('create-hash')
+const fixtures = require('./fixtures/rfc6979')
+const rfc6979 = require('../rfc6979')
+const ecc = require('../')
+
+fixtures.forEach((f) => {
+  tape('RFC6979', (t) => {
+    t.plan(3)
+
+    const message = Buffer.from(f.message, 'utf8')
+    const m = createHash('sha256').update(message).digest()
+    const d = Buffer.from(f.d, 'hex')
+
+    let i = 0
+    rfc6979(m, d, function (k) {
+      if (i === 0) t.equal(k.toString('hex'), f.k0, message + ' (k0)')
+      if (i === 1) t.equal(k.toString('hex'), f.k1, message + ' (k1)')
+      if (i === 15) t.equal(k.toString('hex'), f.k15, message + ' (k15)')
+      if (i > 15) return true
+      ++i
+      return false
+    }, ecc.isPrivate)
+  })
+})


### PR DESCRIPTION
Based on https://github.com/bitcoinjs/tiny-secp256k1/pull/16

I don't know if this is the best way to do this,   would appreciate some opinions.
Simply for peace of mind that our original RFC6979 impl. is specifically tested (as it was previously).