### PR TITLE
Fix issues for node v13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 sudo: false
 language: node_js
 node_js:
-  - "8"
-  - "9"
   - "10"
   - "12"
+  - "13"
 env:
   - TEST_SUITE=unit
 script: npm run-script $TEST_SUITE

--- a/native/addon.cpp
+++ b/native/addon.cpp
@@ -79,14 +79,22 @@ namespace {
 	unsigned int assumeCompression (const I& info, const A& p) {
 		if (info.Length() <= index) return __isPointCompressed(p) ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED;
 		if (info[index]->IsUndefined()) return SECP256K1_EC_COMPRESSED;
+#if (NODE_MODULE_VERSION > NODE_11_0_MODULE_VERSION)
+		return info[index]->BooleanValue(v8::Isolate::GetCurrent()) ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED;
+#else
 		return info[index]->BooleanValue(Nan::GetCurrentContext()).FromJust() ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED;
+#endif
 	}
 
 	template <size_t index, typename I>
 	unsigned int assumeCompression (const I& info) {
 		if (info.Length() <= index) return SECP256K1_EC_COMPRESSED;
 		if (info[index]->IsUndefined()) return SECP256K1_EC_COMPRESSED;
+#if (NODE_MODULE_VERSION > NODE_11_0_MODULE_VERSION)
+		return info[index]->BooleanValue(v8::Isolate::GetCurrent()) ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED;
+#else
 		return info[index]->BooleanValue(Nan::GetCurrentContext()).FromJust() ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED;
+#endif
 	}
 }
 
@@ -317,7 +325,11 @@ NAN_METHOD(ecdsaVerify) {
 	const auto sig = info[2].As<v8::Object>();
 	auto strict = false;
 	if (info.Length() > 3 && !info[3]->IsUndefined()) {
+#if (NODE_MODULE_VERSION > NODE_11_0_MODULE_VERSION)
+		strict = info[3]->BooleanValue(v8::Isolate::GetCurrent());
+#else
 		strict = info[3]->BooleanValue(Nan::GetCurrentContext()).FromJust();
+#endif
 	}
 
 	secp256k1_pubkey public_key;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiny-secp256k1",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A tiny secp256k1 native/JS wrapper",
   "main": "index.js",
   "gypfile": true,


### PR DESCRIPTION
Fixes v13 support for native bindings.

v13 was throwing errors as per a comment in #45 

We will support v6 and above with JS, and v10 and above with native bindings.