### PR TITLE
Fix: browser context randomization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tiny-secp256k1",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiny-secp256k1",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A tiny secp256k1 JS",
   "homepage": "https://github.com/bitcoinjs/tiny-secp256k1#readme",
   "bugs": {

--- a/src_ts/rand.browser.ts
+++ b/src_ts/rand.browser.ts
@@ -1,5 +1,10 @@
 export function generateInt32(): number {
   const array = new Uint8Array(4);
   window.crypto.getRandomValues(array);
-  return (array[0] << 3) + (array[1] << 2) + (array[2] << 1) + array[3];
+  return (
+    (array[0] << (3 * 8)) +
+    (array[1] << (2 * 8)) +
+    (array[2] << (1 * 8)) +
+    array[3]
+  );
 }


### PR DESCRIPTION
This function is only used in randomizing the secp context on initialization, and not used in generating the private keys.