### PR TITLE
Feature: Support CommonJS (require) semantics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,12 @@ build-all-clean: clean-built build-all
 
 .PHONY: build-js
 build-js:
-	npx tsc
+	npx tsc && \
+	sed -i -e 's/\.\/wasm_path\.js/.\/wasm_path_cjs.js/g' ./src_ts/wasm_loader.ts && \
+	npx tsc -p tsconfig-cjs.json && \
+	sed -i -e 's/\.\/wasm_path_cjs\.js/.\/wasm_path.js/g' ./src_ts/wasm_loader.ts && \
+	for f in ./lib/cjs/*.js; do mv -- "$$f" "$${f%.js}.cjs"; done && \
+	for f in ./lib/cjs/*.cjs; do sed -i -e 's/\(require(".*\)\.js");/\1.cjs");/g' -- "$$f"; done
 
 .PHONY: build-wasm
 build-wasm:

--- a/examples/random-in-node/index.js
+++ b/examples/random-in-node/index.js
@@ -128,6 +128,7 @@ function isValidData(data) {
 }
 
 export function generate() {
+  let retryCount = 30;
   for (;;) {
     const seckey = new Uint8Array(randomBytes(32));
     const seckey2 = new Uint8Array(randomBytes(32));
@@ -158,5 +159,7 @@ export function generate() {
     };
 
     if (isValidData(data)) return data;
+    if (retryCount <= 0) throw new Error(`Couldn't generate valid data.`);
+    retryCount--;
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,17 @@
   },
   "license": "MIT",
   "type": "module",
-  "main": "./lib/index.js",
+  "exports": {
+    ".": {
+      "node": {
+        "module": "./lib/index.js",
+        "require": "./lib/cjs/index.cjs",
+        "import": "./lib/index.js"
+      },
+      "browser": "./lib/index.js",
+      "default": "./lib/index.js"
+    }
+  },
   "browser": {
     "./lib/rand.js": "./lib/rand.browser.js",
     "./lib/wasm_loader.js": "./lib/wasm_loader.browser.js"

--- a/src_ts/wasm_loader.ts
+++ b/src_ts/wasm_loader.ts
@@ -1,11 +1,9 @@
 import { readFileSync } from "fs";
-import { URL } from "url";
+import { path } from "./wasm_path.js";
 import * as rand from "./rand.js";
 import * as validate_error from "./validate_error.js";
 
-const { pathname } = new URL("secp256k1.wasm", import.meta.url);
-
-const binary = readFileSync(pathname);
+const binary = readFileSync(path("secp256k1.wasm"));
 const imports = {
   "./rand.js": rand,
   "./validate_error.js": validate_error,

--- a/src_ts/wasm_path.ts
+++ b/src_ts/wasm_path.ts
@@ -1,0 +1,6 @@
+import { URL } from "url";
+
+export function path(wasmFilename: string): string {
+  const { pathname } = new URL(wasmFilename, import.meta.url);
+  return pathname;
+}

--- a/src_ts/wasm_path_cjs.ts
+++ b/src_ts/wasm_path_cjs.ts
@@ -1,0 +1,9 @@
+import * as nodePath from "path";
+
+export function path(wasmFilename: string): string {
+  // Since we know this file will only be used by cjs
+  // and we know that wasm file will always be in the parent dir
+  // We can translate to the parent directory without problem
+  const pathname = nodePath.join(__dirname, "..", wasmFilename);
+  return pathname;
+}

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "checkJs": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "moduleResolution": "node",
+    "baseUrl": "src_ts"
+  },
+  "include": ["src_ts/*.ts"]
+}

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig-base.json",
+  "compilerOptions": {
+    "target": "ES2015",
+    "module": "commonjs",
+    "outDir": "./lib/cjs",
+    "paths": {
+      "#wasm_path": ["./wasm_path_cjs.js"]
+    }
+  },
+  "exclude": ["src_ts/wasm_path.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,13 @@
 {
+  "extends": "./tsconfig-base.json",
   "compilerOptions": {
     "target": "ES2015",
     "module": "ES2020",
-    "checkJs": true,
     "declaration": true,
     "outDir": "./lib",
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "moduleResolution": "node"
+    "paths": {
+      "#wasm_path": ["./wasm_path.js"]
+    }
   },
-  "include": ["src_ts/*.ts"]
+  "exclude": ["src_ts/wasm_path_cjs.ts"]
 }


### PR DESCRIPTION
Currently v2 only supports modules. This makes it hard for people using tooling that doesn't support ESM yet.

This will allow someone to use require against this package, making tools like ts-node work while maintaining compatibility with ESM simultaneously.