### PR TITLE
chore: add recover() extras

### DIFF
--- a/benches/index.js
+++ b/benches/index.js
@@ -105,6 +105,13 @@ const benchmarks = [
     ),
   },
   {
+    name: "privateNegate",
+    // use data from privateSub
+    bench: createBenchmarkFn(fprivates.privateSub, (secp256k1, f) =>
+      secp256k1.privateNegate(f.d)
+    ),
+  },
+  {
     name: "sign",
     bench: createBenchmarkFn(fecdsa, (secp256k1, f) =>
       secp256k1.sign(f.m, f.d)

--- a/examples/react-app/index.js
+++ b/examples/react-app/index.js
@@ -1431,7 +1431,7 @@ const ApiPrivateNegate = withStyles(useStyles)(
       return (
         <>
           <Typography variant="h6">
-            privateSub(d: Uint8Array, tweak: Uint8Array) =&gt; Uint8Array | null
+            privateNegate(d: Uint8Array, tweak: Uint8Array) =&gt; Uint8Array
           </Typography>
           <TextField
             label="Private Key as HEX string"


### PR DESCRIPTION
This is a follow-up on: PR https://github.com/bitcoinjs/tiny-secp256k1/pull/69.
This PR does not change any functionality.

- [x] add benchmark for `privateNegate()`
- [x] add UI for `signRecoverable()`
- [x] add UI for `privateNegate()`

### Benchmark
```
====================================================================================================
Benchmarking function: privateNegate
----------------------------------------------------------------------------------------------------
tiny-secp256k1 (WASM): 0.26 us/op (3795173.00 op/s), ±10.94 %
```

### Sign Recoverable UI
![image](https://user-images.githubusercontent.com/2951406/150635137-d294a21a-8878-4ade-8c82-a13ef0a51d60.png)


### Private Negate UI
![image](https://user-images.githubusercontent.com/2951406/150635145-5fe4a9a4-e57b-44d1-ae19-354bd7d5d272.png)
