### PR TITLE
Fix Dockerfile for build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,14 +52,13 @@ RUN useradd -ms /bin/bash builduser
 USER builduser
 
 # Install Rust (using ./rust-toolchain version)
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y \
-    --profile minimal
-# Install additional components and target (using ./rust-toolchain version)
 WORKDIR /home/builduser/
 COPY rust-toolchain .
-ENV PATH=/home/builduser/.cargo/bin:$PATH
-RUN rustup component add clippy rustfmt rust-src
-RUN rustup target add wasm32-unknown-unknown
-RUN rm rust-toolchain
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y \
+    --default-toolchain $(cat rust-toolchain) \
+    --profile minimal \
+    --component clippy,rustfmt,rust-src \
+    --target wasm32-unknown-unknown \
+    && rm rust-toolchain
 
 CMD Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 & export DISPLAY=':99.0' && bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN curl -sSf https://apt.llvm.org/llvm.sh | bash -s -- 12 && \
 # Install wasm-opt from binaryen
 RUN git clone --depth 1 --branch version_114 https://github.com/WebAssembly/binaryen.git /binaryen && \
   cd /binaryen && \
+  git submodule update --init && \
   cmake . && \
   make -j$(nproc) && \
   make install && \
@@ -50,11 +51,15 @@ RUN git clone --depth 1 --branch version_114 https://github.com/WebAssembly/bina
 RUN useradd -ms /bin/bash builduser
 USER builduser
 
-# Install Rust stable
+# Install Rust (using ./rust-toolchain version)
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y \
-    --default-toolchain stable \
-    --profile minimal \
-    --component clippy,rustfmt,rust-src \
-    --target wasm32-unknown-unknown
+    --profile minimal
+# Install additional components and target (using ./rust-toolchain version)
+WORKDIR /home/builduser/
+COPY rust-toolchain .
+ENV PATH=/home/builduser/.cargo/bin:$PATH
+RUN rustup component add clippy rustfmt rust-src
+RUN rustup target add wasm32-unknown-unknown
+RUN rm rust-toolchain
 
 CMD Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 & export DISPLAY=':99.0' && bash


### PR DESCRIPTION
In this PR, I have made the following changes to the Dockerfile:
- Git submodules are now initialized during the binaryen installation process.
- Rust installation has been modified to use the version specified in the ./rust-toolchain file, replacing the previously used default stable version.
- Additional Rust components and target are installed based on the version in ./rust-toolchain.
- The rust-toolchain file is removed after installation to maintain a clean working directory.

Fixes #127 