### PR TITLE
validate type can be typed array or buffer

### DIFF
--- a/src_ts/validate.ts
+++ b/src_ts/validate.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "buffer";
 import {
   ERROR_BAD_PRIVATE,
   ERROR_BAD_POINT,
@@ -31,8 +32,8 @@ const BN32_P_MINUS_N = new Uint8Array([
   196, 64, 45, 161, 114, 47, 201, 186, 238,
 ]);
 
-function isUint8Array(value: Uint8Array): boolean {
-  return value instanceof Uint8Array;
+function isUint8Array(value: any): boolean {
+  return value instanceof Uint8Array || value instanceof Buffer;
 }
 
 function cmpBN32(data1: Uint8Array, data2: Uint8Array): number {


### PR DESCRIPTION
Not sure if this is desirable and not really clear to me how tiny-secp256k1 is validating in other environments, but this resolves #136 for me. At some level though it makes sense that if bitcoinjs-lib passes the ecc library a Buffer but it's expecting explicitly an Uint8Array that that might be a problem.