### PR TITLE
feat: add Uint8Array input type support to v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiny-secp256k1",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "A tiny secp256k1 native/JS wrapper",
   "main": "index.js",
   "gypfile": true,

--- a/tests/index.js
+++ b/tests/index.js
@@ -12,3 +12,11 @@ try {
 } catch (e) {
   console.warn('Could not test NATIVE bindings')
 }
+
+// Convert all arguments to Uint8Array and test that it returns equivalent results
+const uintWrap = (f) => (...args) => f(...args.map(x => Buffer.isBuffer(x) ? new Uint8Array(x) : x))
+const jsUint = Object.fromEntries(Object.entries(js).map(([k, v]) => [k, uintWrap(v)]))
+
+require('./ecdsa')(jsUint)
+require('./privates')(jsUint)
+require('./points')(jsUint)


### PR DESCRIPTION
Currently:
 * v1 supports `Buffer` instances as input and returns `Buffer` instances as output
 * v2 supports any `Uint8Array` instances (including `Buffer` instances) as input and returns `Uint8Array`
 * v1 has 148k [downloads/week](https://www.npmjs.com/package/tiny-secp256k1?activeTab=versions), v2 has 38k downloads/week
   i.e. 80% of usage is on v1

This PR makes v1 support  any `Uint8Array` instances (including `Buffer` instances) as input, while still returning `Buffer` instances

In a case when several libs in the same project use `tiny-secp256k1`, while one creates the keys and the other one uses it, this will unblock the migration to v2 for the one _creating the keys_ and will allow v1/v2 to coexist, easing the migration path to v2 (or to any other implementation that implements an Uint8Array-based API)

Existing tests work, new tests are added that wrap the existing testsuite and transform Buffer to Uint8Array as input